### PR TITLE
#11 위치정보를 처리하는 hooks 함수 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'no-useless-concat': 'off',
     'no-use-before-define': 'off',
     'no-shadow': 'off',
+    'no-param-reassign': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/no-array-index-key': 'off',
     'react/prop-types': 'off',

--- a/__mocks__/react-redux.js
+++ b/__mocks__/react-redux.js
@@ -1,0 +1,2 @@
+export const useSelector = jest.fn();
+export const useDispatch = jest.fn();

--- a/src/containers/HomeContainer/index.jsx
+++ b/src/containers/HomeContainer/index.jsx
@@ -1,16 +1,18 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import RecommendMenu from '@/components/pages/home/RecommendMenu';
 import SearchMenu from '@/components/pages/home/SearchMenu';
+import { useGeoLocation } from '@/hooks';
 
 import {
   Wrapper, Title,
 } from './styles';
 
 export default function HomeContainer() {
-  const [menu, setMenu] = useState('');
   const navigate = useNavigate();
+  const { getLatLng } = useGeoLocation();
+  const [menu, setMenu] = useState('');
 
   const handleChangeMenu = (e) => {
     setMenu(e.target.value);
@@ -27,6 +29,10 @@ export default function HomeContainer() {
 
     navigate('/searchResult' + `?keyword=${menu}`);
   };
+
+  useEffect(() => {
+    getLatLng();
+  }, []);
 
   return (
     <Wrapper>

--- a/src/containers/HomeContainer/index.test.jsx
+++ b/src/containers/HomeContainer/index.test.jsx
@@ -1,7 +1,12 @@
 import { render } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
 import HomeContainer from '.';
+
+useSelector.mockImplementation((selector) => selector({
+  latLng: {},
+}));
 
 describe('HomeContainer', () => {
   const renderHomeContainer = () => render(

--- a/src/containers/SearchResultContainer/index.jsx
+++ b/src/containers/SearchResultContainer/index.jsx
@@ -1,33 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
+import { useSelector } from 'react-redux';
 import KakaoMap from '@/components/common/KakaoMap';
-import { isEmptyObj } from '@/utils/common';
+import { useGeoLocation } from '@/hooks';
 
 export default function SearchResultContainer({ keyword }) {
-  const [latLng, setLatLng] = useState({});
-
-  const getLatLng = () => {
-    navigator.geolocation.getCurrentPosition(handleSuccess, handleError);
-  };
-
-  const handleSuccess = (position) => {
-    const { latitude, longitude } = position.coords;
-
-    setLatLng({
-      latitude,
-      longitude,
-    });
-  };
-
-  const handleError = () => {
-    window.alert('위치를 허용해주세요');
-  };
+  const { latLng } = useSelector((state) => state);
+  const { getLatLng, isNoLatLng } = useGeoLocation();
 
   useEffect(() => {
     getLatLng();
   }, []);
 
-  if (!keyword || isEmptyObj(latLng)) {
+  if (!keyword || isNoLatLng(latLng)) {
     return (
       <div>
         Loading...

--- a/src/containers/SearchResultContainer/index.test.jsx
+++ b/src/containers/SearchResultContainer/index.test.jsx
@@ -1,6 +1,11 @@
 import { render } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 
 import SearchResultContainer from '.';
+
+useSelector.mockImplementation((selector) => selector({
+  latLng: {},
+}));
 
 describe('SearchResultContainer', () => {
   const renderSearchResultContainer = ({

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useGeoLocation } from './useGeoLocation';

--- a/src/hooks/useGeoLocation.js
+++ b/src/hooks/useGeoLocation.js
@@ -1,0 +1,42 @@
+import { useSelector, useDispatch } from 'react-redux';
+
+import { setLatLng } from '@/slices';
+
+export default function useGeoLocation() {
+  const dispatch = useDispatch();
+  const { latLng } = useSelector((state) => state);
+
+  const isNoLatLng = (latLng) => {
+    const { latitude, longitude } = latLng;
+
+    if (latitude === 0 || longitude === 0) {
+      return true;
+    }
+
+    return false;
+  };
+
+  const getLatLng = () => {
+    if (isNoLatLng(latLng)) {
+      navigator.geolocation.getCurrentPosition(handleGetLatLngSuccess, handleGetLatLngError);
+    }
+  };
+
+  const handleGetLatLngSuccess = (position) => {
+    const { latitude, longitude } = position.coords;
+
+    dispatch(setLatLng({
+      latitude,
+      longitude,
+    }));
+  };
+
+  const handleGetLatLngError = () => {
+    window.alert('위치를 허용해주세요');
+  };
+
+  return {
+    isNoLatLng,
+    getLatLng,
+  };
+}

--- a/src/pages/HomePage/index.test.jsx
+++ b/src/pages/HomePage/index.test.jsx
@@ -1,7 +1,12 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 import HomePage from '.';
+
+useSelector.mockImplementation((selector) => selector({
+  latLng: {},
+}));
 
 describe('HomePage', () => {
   const renderHomePage = () => render(

--- a/src/slices/actions.test.js
+++ b/src/slices/actions.test.js
@@ -1,0 +1,19 @@
+import { initialState, actions, reducer } from '.';
+
+const { setLatLng } = actions;
+
+describe('actions', () => {
+  describe('setLatLng', () => {
+    const latLng = {
+      latitude: 37.125,
+      longitude: 125.125,
+    };
+
+    it('위,경도 값을 저장한다.', () => {
+      const state = reducer(initialState, setLatLng(latLng));
+
+      expect(state.latLng.latitude).toBe(latLng.latitude);
+      expect(state.latLng.longitude).toBe(latLng.longitude);
+    });
+  });
+});

--- a/src/slices/index.js
+++ b/src/slices/index.js
@@ -1,18 +1,24 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-const initialState = {
-
+export const initialState = {
+  latLng: {
+    latitude: 0,
+    lngitude: 0,
+  },
 };
 
 const appSlice = createSlice({
   name: 'app',
   initialState,
   reducers: {
-
+    setLatLng(state, action) {
+      state.latLng = action.payload;
+    },
   },
 
-})
+});
 
 export const { actions, reducer } = appSlice;
+export const { setLatLng } = actions;
 
 export default reducer;


### PR DESCRIPTION
- 홈 페이지에서부터 위치정보를 미리 읽어서, 검색 결과 페이지에서 맵을 좀 더 빠르게 띄울 수 있도록 처리
- 위치 정보가 없으면, 검색 결과 페이지에서 다시 정보 요청 시도